### PR TITLE
UPDT-796 Revert "chore: Bump mainnet version to v1.69.2."

### DIFF
--- a/group_vars/mainnet.yml
+++ b/group_vars/mainnet.yml
@@ -2,12 +2,12 @@
 # maintains versions and can overwrite all.yml
 sui:
   validator:
-    version: 33ef98b2337036b06f9da3927715a411dcddfc40
+    version: 3c0f387ebb40b8be292d3b7bd3f5bee8ad226d33
     external_address: validator.sui.mainnet.encapsulate.xyz
   fullnode:
-    version: 33ef98b2337036b06f9da3927715a411dcddfc40
+    version: 3c0f387ebb40b8be292d3b7bd3f5bee8ad226d33
   bridge:
-    version: 33ef98b2337036b06f9da3927715a411dcddfc40
+    version: 3c0f387ebb40b8be292d3b7bd3f5bee8ad226d33
   dummy:
-    version: 33ef98b2337036b06f9da3927715a411dcddfc40
+    version: 3c0f387ebb40b8be292d3b7bd3f5bee8ad226d33
     external_address: dummy.sui.mainnet.encapsulate.xyz


### PR DESCRIPTION
This reverts commit a3f67e6168f916d2d7e4467c05e9c69ae983d9af.